### PR TITLE
upper to lower case letter

### DIFF
--- a/fr_CA/Bundle_fr.properties
+++ b/fr_CA/Bundle_fr.properties
@@ -1939,8 +1939,8 @@ mydataFragment.publicationStatus=Statut de publication
 mydataFragment.roles=Rôles
 mydataFragment.resultsByUserName=Résultats par nom d'utilisateur
 mydataFragment.search=Rechercher mes données\u2026
-mydata.result=Résultat
-mydata.results=Résultats
+mydata.result=résultat
+mydata.results=résultats
 mydata.viewnext=Voir les prochain(e)s
 mydata.more=restant(e)s
 


### PR DESCRIPTION
Minor fix : I removed the upper case letters ;  lower case is needed for
correct display of button text at the bottom when searching e.g. "Voir les
prochains 10 résultats"